### PR TITLE
fix: include headers on interactions requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pactflow/pact-msw-adapter",
+  "name": "@s-ui/pact-msw-adapter",
   "version": "1.2.0",
   "main": "./dist/pactMswAdapter.js",
   "keywords": [

--- a/src/convertMswMatchToPact.ts
+++ b/src/convertMswMatchToPact.ts
@@ -21,8 +21,8 @@ export const convertMswMatchToPact = ({
         method: match.request.method,
         path: match.request.url.pathname,
         headers: headers?.excludeHeaders
-          ? omit(match.request.headers['_headers'], headers.excludeHeaders)
-          : match.request.headers['_headers'],
+          ? omit(Object.fromEntries(match.request.headers.entries()), headers.excludeHeaders)
+          : Object.fromEntries(match.request.headers.entries()),
         body: match.request.body || undefined,
         query: match.request.url.search ? match.request.url.search.split('?')[1] : undefined
       },


### PR DESCRIPTION
<!-- Thank you for making a pull request! -->

<!-- pact-msw-adapter is built and maintained by developers like you, and we appreciate contributions very much. You are awesome! -->

<!-- Our changelog is automatically built from our commit history, using conventional changelog. This means we'd like to take care that: -->

<!-- - commit messages with the prefix `fix:` or `fix(foo):` are suitable to be added to the changelog under "Fixes and improvements" -->
<!-- - commit messages with the prefix `feat:` or `feat(foo):` are suitable to be added to the changelog under "New features" -->

<!-- If you've made many commits that don't adhere to this style, we recommend squashing
your commits to a new branch before making a PR. Alternatively, we can do a squash
merge, but you'll lose attribution for your change. -->

<!-- For more information please see CONTRIBUTING.md -->

### Checklist

- [x] `yarn run dist:ci` passes on my machine
- [x] I have followed the commit message guidelines, with messages suitable for appearing in the changelog

### Description

<!-- _Please describe what this PR is for, or link the issue that this PR fixes_ -->

When a request is done, for example, from `axios` fetcher, and it's intercepted by MSW, the final pact file doesn't include the request headers. This PR fixes this unexpected behaviour.

<!-- _You may add as much or as little context as you like here, whatever you think is right_ -->

<!-- _Thanks again!_ -->
